### PR TITLE
added maven running integration tests configuration support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,50 @@
 
 	<build>
 		<plugins>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.9.1</version>
+				<executions>
+					<execution>
+						<id>add-it-source</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>src/integration-test/java</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.5</version>
+				<executions>
+					<execution>
+						<id>add-it-resources</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>target/it-test-classes</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/integration-test/resources</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
@@ -220,6 +264,20 @@
 					<source>${java.version}</source>
 					<target>${java.version}</target>
 				</configuration>
+				<executions>
+					<execution>
+						<id>compile-integration-test</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+						<configuration>
+							<testIncludes>
+								<testInclude>**/*IT.java</testInclude>
+							</testIncludes>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>
@@ -229,6 +287,33 @@
 				<configuration>
 					<skipTests>false</skipTests>
 				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.18</version>
+				<executions>
+					<execution>
+						<id>integration-test</id>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+						<configuration>
+							<testSourceDirectory>src/integration-test/java</testSourceDirectory>
+							<!-- reusing same unit test folder -->
+							<testClassesDirectory>target/test-classes</testClassesDirectory>
+							<!--<includes>
+                                <include></include>
+                            </includes>-->
+							<excludes>
+								<exclude>**/*Test.java</exclude>
+							</excludes>
+							<skipTests>false</skipTests>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
maven integration test configuration, using failsafe plugin - having tests located in separate test folder and allow running both unit test and integration tests yet separate at same time. Although, both compile test sources to same test target folder